### PR TITLE
Updates for newer Macaulay2 versions

### DIFF
--- a/R/factor_n.R
+++ b/R/factor_n.R
@@ -99,10 +99,18 @@ factor_n <- function (n, code = FALSE, ...) {
   parsed_out <- m2_parse(pointer)
 
   # reformat and return
-  list(
-    prime = vapply(parsed_out, `[[`, integer(1), 1),
-    power = vapply(parsed_out, `[[`, integer(1), 2)
-  )
+
+  if (class(parsed_out)[1] == "m2_minus") {
+    list(
+      prime = c(-1L, vapply(parsed_out[[1]], `[[`, integer(1), 1)),
+      power = c(1L, vapply(parsed_out[[1]], `[[`, integer(1), 2))
+    )
+  } else {
+    list(
+      prime = vapply(parsed_out, `[[`, integer(1), 1),
+      power = vapply(parsed_out, `[[`, integer(1), 2)
+    )
+  }
 
 }
 

--- a/tests/testthat/test-ideal.R
+++ b/tests/testthat/test-ideal.R
@@ -176,7 +176,7 @@ test_that("ideal_.(poly_chars)",{
     m2_name = m2_name(actual),
     m2_class = "m2_pointer",
     m2_meta = list(
-      ext_str = sprintf("ideal map((%1$s)^1,(%1$s)^{{-1},{-2}},{{x+y, x^2+y^2}})", m2_name(R)),
+      ext_str = sprintf("ideal map(%1$s^1,%1$s^{{-1}, {-2}},{{x+y, x^2+y^2}})", m2_name(R)),
       m2_class = "Ideal",
       m2_class_class = "Type"
     )
@@ -198,7 +198,7 @@ test_that("ideal_.(mpolyList)",{
     m2_name = m2_name(actual),
     m2_class = "m2_pointer",
     m2_meta = list(
-      ext_str = sprintf("ideal map((%1$s)^1,(%1$s)^{{-1},{-2}},{{x+y, x^2+y^2}})", m2_name(R)),
+      ext_str = sprintf("ideal map(%1$s^1,%1$s^{{-1}, {-2}},{{x+y, x^2+y^2}})", m2_name(R)),
       m2_class = "Ideal",
       m2_class_class = "Type"
     )
@@ -220,7 +220,7 @@ test_that("ideal_.(list o chars)",{
     m2_name = m2_name(actual),
     m2_class = "m2_pointer",
     m2_meta = list(
-      ext_str = sprintf("ideal map((%1$s)^1,(%1$s)^{{-1},{-2}},{{x+y, x^2+y^2}})", m2_name(R)),
+      ext_str = sprintf("ideal map(%1$s^1,%1$s^{{-1}, {-2}},{{x+y, x^2+y^2}})", m2_name(R)),
       m2_class = "Ideal",
       m2_class_class = "Type"
     )
@@ -242,7 +242,7 @@ test_that("ideal_.(list o mps)",{
     m2_name = m2_name(actual),
     m2_class = "m2_pointer",
     m2_meta = list(
-      ext_str = sprintf("ideal map((%1$s)^1,(%1$s)^{{-1},{-2}},{{x+y, x^2+y^2}})", m2_name(R)),
+      ext_str = sprintf("ideal map(%1$s^1,%1$s^{{-1}, {-2}},{{x+y, x^2+y^2}})", m2_name(R)),
       m2_class = "Ideal",
       m2_class_class = "Type"
     )
@@ -264,7 +264,7 @@ test_that("ideal_.(list o chars, raw_chars = TRUE)",{
     m2_name = m2_name(actual),
     m2_class = "m2_pointer",
     m2_meta = list(
-      ext_str = sprintf("ideal map((%1$s)^1,(%1$s)^{{-1},{-2}},{{x+y, x^2+y^2}})", m2_name(R)),
+      ext_str = sprintf("ideal map(%1$s^1,%1$s^{{-1}, {-2}},{{x+y, x^2+y^2}})", m2_name(R)),
       m2_class = "Ideal",
       m2_class_class = "Type"
     )
@@ -286,7 +286,7 @@ test_that("ideal_.(poly_chars, raw_chars = TRUE)",{
     m2_name = m2_name(actual),
     m2_class = "m2_pointer",
     m2_meta = list(
-      ext_str = sprintf("ideal map((%1$s)^1,(%1$s)^{{-1},{-2}},{{x+y, x^2+y^2}})", m2_name(R)),
+      ext_str = sprintf("ideal map(%1$s^1,%1$s^{{-1}, {-2}},{{x+y, x^2+y^2}})", m2_name(R)),
       m2_class = "Ideal",
       m2_class_class = "Type"
     )

--- a/tests/testthat/test-m2_matrix.R
+++ b/tests/testthat/test-m2_matrix.R
@@ -57,7 +57,7 @@ test_that("m2_matrix.(mat)", {
     class = c("m2_pointer", "m2"),
     m2_name = m2_name(actual),
     m2_meta = list(
-      ext_str = "map((ZZ)^4,(ZZ)^3,{{1, 2, 3}, {1, 34, 45}, {2213, 1123, 6543}, {0, 0, 0}})",
+      ext_str = "map(ZZ^4,ZZ^3,{{1, 2, 3}, {1, 34, 45}, {2213, 1123, 6543}, {0, 0, 0}})",
       m2_class = "Matrix",
       m2_class_class = "Type"
     )


### PR DESCRIPTION
Running the test suite using Macaulay2 1.19 currently gives:

```r
> test_check("m2r")
M2 Ring: CC[x,y], grevlex order
══ Failed tests ════════════════════════════════════════════════════════════════
── Error (test-factor_n.R:39:3): factor_n(negative) ────────────────────────────
Error: values must be length 1,
 but FUN(X[[1]]) result is length 2
Backtrace:
    █
 1. ├─testthat::expect_equal(...) test-factor_n.R:39:2
 2. │ └─testthat::quasi_label(enquo(object), label, arg = "object")
 3. │   └─rlang::eval_bare(expr, quo_get_env(quo))
 4. └─m2r::factor_n(-55)
 5.   └─base::vapply(parsed_out, `[[`, integer(1), 1)
── Failure (test-ideal.R:185:3): ideal_.(poly_chars) ───────────────────────────
`actual` not equal to `expect`.
Attributes: < Component “m2_meta”: Component “ext_str”: 1 string mismatch >
── Failure (test-ideal.R:207:3): ideal_.(mpolyList) ────────────────────────────
`actual` not equal to `expect`.
Attributes: < Component “m2_meta”: Component “ext_str”: 1 string mismatch >
── Failure (test-ideal.R:229:3): ideal_.(list o chars) ───────────────────────────
`actual` not equal to `expect`.
Attributes: < Component “m2_meta”: Component “ext_str”: 1 string mismatch >
── Failure (test-ideal.R:251:3): ideal_.(list o mps) ───────────────────────────
`actual` not equal to `expect`.
Attributes: < Component “m2_meta”: Component “ext_str”: 1 string mismatch >
── Failure (test-ideal.R:273:3): ideal_.(list o chars, raw_chars = TRUE) ───────────────────────────
`actual` not equal to `expect`.
Attributes: < Component “m2_meta”: Component “ext_str”: 1 string mismatch >
── Failure (test-ideal.R:295:3): ideal_.(poly_chars, raw_chars = TRUE) ───────────────────────────
`actual` not equal to `expect`.
Attributes: < Component “m2_meta”: Component “ext_str”: 1 string mismatch >
── Failure (test-m2_matrix.R:66:3): m2_matrix.(mat) ────────────────────────────
`actual` not equal to `expect`.
Attributes: < Component “m2_meta”: Component “ext_str”: 1 string mismatch >

[ FAIL 8 | WARN 0 | SKIP 0 | PASS 138 ]
Error: Test failures
Execution halted
```

This is because of two issues:

* `factor(ZZ)` now returns a `Minus` object instead of a `Product` one containing -1, so `factor_n` was failing for negative integers. (since M2 1.16 -- see https://github.com/Macaulay2/M2/pull/1096)
* `toExternalString(Matrix)` now returns slightly different output (since M2 1.17 -- see https://github.com/Macaulay2/M2/pull/1725)

This PR updates `factor_n` to handle the first issue and updates the expected output for matrices to handle the second.
